### PR TITLE
substitute cluster object for the newer managedcluster

### DIFF
--- a/3.md
+++ b/3.md
@@ -10,7 +10,7 @@ RHACM also having GitOps capabilities for deploying and managing Kubernetes serv
 
 ![GitOps](assets/gitops.png)
 
-## RHACM 
+## RHACM
 
 ## Installing Red Hat Advanced Cluster Management for Kubernetes
 
@@ -25,17 +25,17 @@ You can then get the WebUI url for your just installed RHACM with this command:
 ~~~sh
 oc  --context hubcluster -n open-cluster-management get route multicloud-console  -o jsonpath="{.status.ingress[*].host}{\"\n\"}"
 ~~~
- 
+
 ## Adding Clusters
 
 After accessing RHACM WebUI you can then import your clusters following the official documentation: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/1.0/html/manage_cluster/index
 
-## List the available clusters 
+## List the available clusters
 
 After completing the import you should be able to see the just imported clusters:
 
 ~~~sh
-oc get clusters -A --show-labels
+oc get managedclusters -A --show-labels
 as4test     as4test     api.as4test.lp.int:6443           Ready     1d
 heisenbug   heisenbug   api.heisenbug.lplab.online:6443   Ready     1d
 jelly       jelly       api.jelly.lplab.online:6443       Ready     1d
@@ -48,15 +48,15 @@ For achieving the right placement of the next labs, you'll need to set a label f
 ***Please Note: pay attention to assign the right label to the respective cluster.***
 
 ~~~sh
-oc label cluster -n YOUR_ACM_CLUSTER1_NAME YOUR_ACM_CLUSTER1_NAME clusterid=cluster1
-oc label cluster -n YOUR_ACM_CLUSTER2_NAME YOUR_ACM_CLUSTER2_NAME clusterid=cluster2
-oc label cluster -n YOUR_ACM_CLUSTER3_NAME YOUR_ACM_CLUSTER3_NAME clusterid=cluster3
+oc label managedcluster -n YOUR_ACM_CLUSTER1_NAME YOUR_ACM_CLUSTER1_NAME clusterid=cluster1
+oc label managedcluster -n YOUR_ACM_CLUSTER2_NAME YOUR_ACM_CLUSTER2_NAME clusterid=cluster2
+oc label managedcluster -n YOUR_ACM_CLUSTER3_NAME YOUR_ACM_CLUSTER3_NAME clusterid=cluster3
 ~~~
 
 You can check the correct labeling by executing this command:
 
 ~~~sh
-oc get clusters -A --show-labels
+oc get managedclusters -A --show-labels
 ~~~
 
 

--- a/lab-5-assets/overlays/cluster1/route.yaml
+++ b/lab-5-assets/overlays/cluster1/route.yaml
@@ -3,4 +3,4 @@ kind: Route
 metadata:
   name: the-route
 spec:
-  host: changeme
+  host: web-app.apps.dev.a4e4.sandbox1545.opentlc.com

--- a/lab-5-assets/overlays/cluster2/route.yaml
+++ b/lab-5-assets/overlays/cluster2/route.yaml
@@ -3,4 +3,4 @@ kind: Route
 metadata:
   name: the-route
 spec:
-  host: changeme
+  host: web-app.apps.cluster-df04.gcp.testdrive.openshift.com

--- a/lab-5-assets/overlays/cluster3/route.yaml
+++ b/lab-5-assets/overlays/cluster3/route.yaml
@@ -3,4 +3,4 @@ kind: Route
 metadata:
   name: the-route
 spec:
-  host: changeme
+  host: web-app.apps.cluster-ec17.ec17.sandbox28.opentlc.com


### PR DESCRIPTION
Referring to the opened PR identified this issue (https://github.com/ansonmez/rhacmgitopslab/issues/4) we can use the managedclusters object instead of the cluster CR in newer versions of ACM:

```
# oc get managedcluster
NAME            HUB ACCEPTED   MANAGED CLUSTER URLS   JOINED   AVAILABLE   AGE
dev             true                                  True     True        5h10m
local-cluster   true                                  True     True        24h
prod            true                                  True     True        85m
qa              true                                  True     True        58m
```
Also can be labeled as the PR fixes:
```
# oc label managedcluster -n dev dev clusterid=cluster1
managedcluster.cluster.open-cluster-management.io/dev labeled
```

```
oc get managedclusters -A --show-labels
NAME            HUB ACCEPTED   MANAGED CLUSTER URLS   JOINED   AVAILABLE   AGE     LABELS
dev             true                                  True     True        5h13m   cloud=Amazon,clusterID=xxxx,clusterid=cluster1,env=dev,environment=dev,name=dev,region=eu-west-1,vendor=OpenShift
local-cluster   true                                  True     True        24h     cloud=Amazon,clusterID=xxxx,installer.name=multiclusterhub,installer.namespace=open-cluster-management,local-cluster=true,name=local-cluster,vendor=OpenShift
prod            true                                  True     True        88m     cloud=AWS,clusterID=xxxx,clusterid=cluster3,env=prod,environment=prod,name=prod,vendor=OpenShift
qa              true                                  True     True        61m     cloud=GCP,clusterID=xxxx,clusterid=cluster2,env=qa,environment=qa,name=qa,vendor=OpenShift
```
